### PR TITLE
Check if ad_integration module exists, before trying to get the service

### DIFF
--- a/infinite_base.module
+++ b/infinite_base.module
@@ -242,7 +242,7 @@ function infinite_base_get_all_parents($term) {
  * Implements hook_preprocess_node().
  */
 function infinite_base_preprocess_node(&$variables) {
-  if ($variables['view_mode'] == 'full' || $variables['view_mode'] == 'lazyloading') {
+  if ($variables['view_mode'] == 'full' || $variables['view_mode'] == 'lazyloading' && \Drupal::moduleHandler()->moduleExists('ad_integration')) {
     /* @var \Drupal\ad_integration\AdIntegration $advertisingService */
     $advertisingService = \Drupal::service('ad_integration');
     if (is_object($advertisingService)) {

--- a/infinite_base.module
+++ b/infinite_base.module
@@ -242,7 +242,7 @@ function infinite_base_get_all_parents($term) {
  * Implements hook_preprocess_node().
  */
 function infinite_base_preprocess_node(&$variables) {
-  if ($variables['view_mode'] == 'full' || $variables['view_mode'] == 'lazyloading' && \Drupal::moduleHandler()->moduleExists('ad_integration')) {
+  if ( ($variables['view_mode'] == 'full' || $variables['view_mode'] == 'lazyloading') && \Drupal::moduleHandler()->moduleExists('ad_integration')) {
     /* @var \Drupal\ad_integration\AdIntegration $advertisingService */
     $advertisingService = \Drupal::service('ad_integration');
     if (is_object($advertisingService)) {


### PR DESCRIPTION
This is necessary, because we moved the ad_integration from thunder to the thunder_infrastructure, making it an optional module.
