### PR TITLE
 INREL-3499 fix duplicate <h1> in amp pages

### DIFF
--- a/modules/infinite_blocks/infinite_blocks.module
+++ b/modules/infinite_blocks/infinite_blocks.module
@@ -21,7 +21,11 @@ function infinite_blocks_theme() {
       'variables' => array('outbrain' => NULL),
     ),
     'logo_header' => array(
-      'variables' => array('logo' => NULL, 'front_page' => NULL)
+      'variables' => array(
+        'logo' => NULL,
+        'front_page' => NULL,
+        'is_front' => null,
+      )
     ),
     'logo' => array(
       'variables' => array('logo' => NULL, 'front_page' => NULL)
@@ -160,6 +164,9 @@ function infinite_blocks_preprocess_block(&$variables) {
           $variables['content']['#include_wishlist_icon'] = true;
         }
       }
+    }
+    if ('infinite_blocks_logo_header' === $variables['base_plugin_id']) {
+      $variables['content']['#is_front'] = \Drupal::service('path.matcher')->isFrontPage();
     }
   }
 }

--- a/modules/infinite_blocks/templates/logo-header.html.twig
+++ b/modules/infinite_blocks/templates/logo-header.html.twig
@@ -1,9 +1,9 @@
-{% if front_page %}
-<h1>
-    {% endif %}
+{% if is_front %}
+    <h1>
+{% endif %}
 
     {% embed 'logo.html.twig' with {'link_url': front_page} %}{% endembed %}
 
-    {% if front_page %}
-</h1>
+{% if is_front %}
+    </h1>
 {% endif %}


### PR DESCRIPTION
## [INREL-3499](https://jira.burda.com/browse/INREL-3499) 
- replaced wrongly used variable front_page (with has the link to the front page) with newly introduced variable is_front

## How to test:
- test on elle
- there should only be one h1 tag in amp pages e.g. http://elle.local/sternzeichen-maenner-angst-vor-gefuehlen?amp

Hint: There is a related issue that there are currently still 2 <h1> on the ELLE frontpage which is not fixed within this issue

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand

