### PR TITLE
INREL-3520: reduce channels from fia

### DIFF
--- a/modules/infinite_ad_entity/infinite_ad_entity.module
+++ b/modules/infinite_ad_entity/infinite_ad_entity.module
@@ -84,12 +84,12 @@ function infinite_ad_entity_theme_suggestions_ad_entity_alter(array &$suggestion
 
 function infinite_ad_entity_preprocess_ad_entity(&$vars){
   if ($vars['container'] == 'html') {
-    _reduceTargetingToOneChannel($vars);
+    _infinite_ad_entity_reduce_to_one_channel($vars);
   }
 }
 
 function infinite_ad_entity_preprocess_adtech_iframe(&$vars) {
-  _reduceTargetingToOneChannel($vars);
+  _infinite_ad_entity_reduce_to_one_channel($vars);
 }
 
 /**
@@ -100,7 +100,7 @@ function infinite_ad_entity_preprocess_adtech_iframe(&$vars) {
  *
  * @throws \Drupal\Core\Entity\EntityStorageException
  */
-function _reduceTargetingToOneChannel(&$vars) {
+function _infinite_ad_entity_reduce_to_one_channel(&$vars) {
   /** @var \Drupal\ad_entity\Entity\AdEntity $ad_entity */
   $ad_entity = $vars['ad_entity'];
 

--- a/modules/infinite_ad_entity/infinite_ad_entity.module
+++ b/modules/infinite_ad_entity/infinite_ad_entity.module
@@ -81,6 +81,17 @@ function infinite_ad_entity_theme_suggestions_ad_entity_alter(array &$suggestion
   $suggestions[] = $hook . '__' . $variables['ad_entity']->id();
 }
 
+
+function infinite_ad_entity_preprocess_ad_entity(&$vars){
+  if ($vars['container'] == 'html') {
+    _reduceTargetingToOneChannel($vars);
+  }
+}
+
+function infinite_ad_entity_preprocess_adtech_iframe(&$vars) {
+  _reduceTargetingToOneChannel($vars);
+}
+
 /**
  * Convert targeting channel from array to string
  *
@@ -89,12 +100,12 @@ function infinite_ad_entity_theme_suggestions_ad_entity_alter(array &$suggestion
  *
  * @throws \Drupal\Core\Entity\EntityStorageException
  */
-function infinite_ad_entity_preprocess_ad_entity(&$vars){
+function _reduceTargetingToOneChannel(&$vars) {
   /** @var \Drupal\ad_entity\Entity\AdEntity $ad_entity */
   $ad_entity = $vars['ad_entity'];
 
   // Only convert for adtech ad entities and html containers.
-  if ($ad_entity->get('type_plugin_id') == 'adtech_factory' && $vars['container'] == 'html') {
+  if ($ad_entity->get('type_plugin_id') == 'adtech_factory') {
 
     /** @var \Drupal\ad_entity\TargetingCollection $targeting_collection */
     $targeting_collection = $ad_entity->getTargetingFromContextData();

--- a/modules/infinite_ad_entity/infinite_ad_entity.module
+++ b/modules/infinite_ad_entity/infinite_ad_entity.module
@@ -94,6 +94,8 @@ function infinite_ad_entity_preprocess_adtech_iframe(&$vars) {
 
 /**
  * Convert targeting channel from array to string
+ * 
+ * TODO: refactor into a service / field formatter
  *
  * @param $vars
  *   Template variables.

--- a/modules/infinite_ad_entity/infinite_ad_entity.module
+++ b/modules/infinite_ad_entity/infinite_ad_entity.module
@@ -84,12 +84,12 @@ function infinite_ad_entity_theme_suggestions_ad_entity_alter(array &$suggestion
 
 function infinite_ad_entity_preprocess_ad_entity(&$vars){
   if ($vars['container'] == 'html') {
-    _infinite_ad_entity_reduce_to_one_channel($vars);
+    _infinite_ad_entity_filter_main_channel($vars);
   }
 }
 
 function infinite_ad_entity_preprocess_adtech_iframe(&$vars) {
-  _infinite_ad_entity_reduce_to_one_channel($vars);
+  _infinite_ad_entity_filter_main_channel($vars);
 }
 
 /**
@@ -100,7 +100,7 @@ function infinite_ad_entity_preprocess_adtech_iframe(&$vars) {
  *
  * @throws \Drupal\Core\Entity\EntityStorageException
  */
-function _infinite_ad_entity_reduce_to_one_channel(&$vars) {
+function _infinite_ad_entity_filter_main_channel(&$vars) {
   /** @var \Drupal\ad_entity\Entity\AdEntity $ad_entity */
   $ad_entity = $vars['ad_entity'];
 


### PR DESCRIPTION
The targeting on FIA contained multiple channels, if a channel and a tag with a channel targeting was set for an article.

This was already the behaviour before the ad_entity update, but we want to fix it here, too.