### PR TITLE
INREL-3764 include next article title

### DIFF
--- a/infinite_base.module
+++ b/infinite_base.module
@@ -136,8 +136,10 @@ function infinite_base_theme() {
     ),
 
     'lazy_loading' => array(
-      'variables' => array('lazy_loading_url' => NULL),
-      'variables' => array('article_title' => NULL)
+      'variables' => array(
+        'lazy_loading_url' => NULL,
+        'article_title' => NULL,
+      )
     ),
   );
 }

--- a/infinite_base.module
+++ b/infinite_base.module
@@ -136,7 +136,8 @@ function infinite_base_theme() {
     ),
 
     'lazy_loading' => array(
-      'variables' => array('lazy_loading_url' => NULL)
+      'variables' => array('lazy_loading_url' => NULL),
+      'variables' => array('article_title' => NULL)
     ),
   );
 }

--- a/modules/infinite_odoscope/js/models/odoscope-article-model.js
+++ b/modules/infinite_odoscope/js/models/odoscope-article-model.js
@@ -20,7 +20,7 @@
     },
     getNextURL: function () {
       var url,
-        model,
+        latestModel,
         variantID,
         loadingIndex;
 
@@ -34,18 +34,18 @@
       /**
        * Set latest Model
        */
-      model = this.get('list').shift();
+      latestModel = this.get('list').shift();
 
       /**
        * Check if properties available
        */
-      if (!tmpModel.hasOwnProperty('variantID')) {
+      if (!latestModel.hasOwnProperty('variantID')) {
         return null;
       }
 
       this.set('loadingIndex', this.get('loadingIndex') + 1);
       loadingIndex = this.get('loadingIndex');
-      variantID = tmpModel.variantID;
+      variantID = latestModel.variantID;
       url = `/lazyloading/node/${variantID}/nojs?page=${loadingIndex}`;
       this.set('currentURL', url);
       console.log("%codoscopeArticleModel | getNextURL", "color: blue; font-weight: bold;", url, this);

--- a/modules/infinite_odoscope/js/models/odoscope-article-model.js
+++ b/modules/infinite_odoscope/js/models/odoscope-article-model.js
@@ -4,7 +4,8 @@
 
   window.OdoscopeArticleModel = BurdaInfinite.models.base.BaseModel.extend({
     defaults: {
-      loadingIndex: 0
+      loadingIndex: 0,
+      currentURL: null,
     },
     initialize: function (pAttributes, pOptions) {
       BurdaInfinite.models.base.BaseModel.prototype.initialize.call(this, pAttributes, pOptions);
@@ -41,7 +42,8 @@
       }
 
       this.set('loadingIndex', this.get('loadingIndex') + 1);
-      tmpURL = '/lazyloading/node/' + tmpModel.variantID + '/nojs?page=' + this.get('loadingIndex');
+      this.set('currentURL', '/lazyloading/node/' + tmpModel.variantID + '/nojs?page=' + this.get('loadingIndex'));
+      tmpURL = this.get('currentURL');
       console.log("%codoscopeArticleModel | getNextURL", "color: blue; font-weight: bold;", tmpURL, this);
       return tmpURL;
     }

--- a/modules/infinite_odoscope/js/models/odoscope-article-model.js
+++ b/modules/infinite_odoscope/js/models/odoscope-article-model.js
@@ -19,10 +19,10 @@
       this.trigger('set:articleModel', this);
     },
     getNextURL: function () {
-      var url,
-        latestModel,
-        variantID,
-        loadingIndex;
+      var url;
+      var latestModel;
+      var variantID;
+      var loadingIndex;
 
       /**
        * Check if an Element in Array exists

--- a/modules/infinite_odoscope/js/models/odoscope-article-model.js
+++ b/modules/infinite_odoscope/js/models/odoscope-article-model.js
@@ -5,7 +5,7 @@
   window.OdoscopeArticleModel = BurdaInfinite.models.base.BaseModel.extend({
     defaults: {
       loadingIndex: 0,
-      currentURL: null,
+      currentURL: '',
     },
     initialize: function (pAttributes, pOptions) {
       BurdaInfinite.models.base.BaseModel.prototype.initialize.call(this, pAttributes, pOptions);
@@ -19,8 +19,10 @@
       this.trigger('set:articleModel', this);
     },
     getNextURL: function () {
-      var tmpURL,
-        tmpModel;
+      var url,
+        model,
+        variantID,
+        loadingIndex;
 
       /**
        * Check if an Element in Array exists
@@ -32,7 +34,7 @@
       /**
        * Set latest Model
        */
-      tmpModel = this.get('list').shift();
+      model = this.get('list').shift();
 
       /**
        * Check if properties available
@@ -42,10 +44,12 @@
       }
 
       this.set('loadingIndex', this.get('loadingIndex') + 1);
-      this.set('currentURL', '/lazyloading/node/' + tmpModel.variantID + '/nojs?page=' + this.get('loadingIndex'));
-      tmpURL = this.get('currentURL');
-      console.log("%codoscopeArticleModel | getNextURL", "color: blue; font-weight: bold;", tmpURL, this);
-      return tmpURL;
+      loadingIndex = this.get('loadingIndex');
+      variantID = tmpModel.variantID;
+      url = `/lazyloading/node/${variantID}/nojs?page=${loadingIndex}`;
+      this.set('currentURL', url);
+      console.log("%codoscopeArticleModel | getNextURL", "color: blue; font-weight: bold;", url, this);
+      return url;
     }
   });
 

--- a/src/Plugin/Block/InfiniteLazyLoadingSimple.php
+++ b/src/Plugin/Block/InfiniteLazyLoadingSimple.php
@@ -44,6 +44,7 @@ class InfiniteLazyLoadingSimple extends BlockBase {
       // Perhaps we could use above code later again.
 
       $next_nid = $query->execute();
+      $title = '';
 
       if (!empty($next_nid)) {
         $page = 1;
@@ -53,6 +54,8 @@ class InfiniteLazyLoadingSimple extends BlockBase {
 
         $next_nid = array_shift($next_nid);
         $lazy_loading_url = '/lazyloading/node/' . $next_nid . '/nojs?page=' . $page;
+        $next_node = Node::load($next_nid);
+        $title = $next_node->getTitle();
       } else {
         $lazy_loading_url = '/home?page=0';
       }
@@ -60,7 +63,7 @@ class InfiniteLazyLoadingSimple extends BlockBase {
       return array(
         '#theme' => 'lazy_loading',
         '#lazy_loading_url' => $lazy_loading_url,
-        '#article_title' => $node->getTitle(),
+        '#article_title' => $title,
         '#attached' => array(
           'library' => array(
             'core/drupal.ajax',

--- a/src/Plugin/Block/InfiniteLazyLoadingSimple.php
+++ b/src/Plugin/Block/InfiniteLazyLoadingSimple.php
@@ -60,6 +60,7 @@ class InfiniteLazyLoadingSimple extends BlockBase {
       return array(
         '#theme' => 'lazy_loading',
         '#lazy_loading_url' => $lazy_loading_url,
+        '#article_title' => $node->getTitle(),
         '#attached' => array(
           'library' => array(
             'core/drupal.ajax',

--- a/templates/lazy-loading.html.twig
+++ b/templates/lazy-loading.html.twig
@@ -1,5 +1,5 @@
 <a class="infinite-more-link use-ajax" href="{{ lazy_loading_url }}"
-   title="Lazy loading of next page" rel="next">
+   title="Lazy loading of next page" data-next-article-title="{{ article_title }}" rel="next">
     <span class="visually-hidden">Next page</span>
     <span aria-hidden="true">next ›</span>
 </a>


### PR DESCRIPTION
## [INREL-3764](https://jira.burda.com/browse/INREL-3764) 
Extend infinite_base.module with (next) article title.
Extend lazy-loading.html.twig with data-next-article-title.

before:
'lazy_loading' => array(
      'variables' => array('lazy_loading_url' => NULL)
    ),

after:
'lazy_loading' => array(
      'variables' => array('lazy_loading_url' => NULL),
      'variables' => array('article_title' => NULL)
    ),

## How to test:
"<a class="infinite-more-link" has now a new "data-next-article-title" attribute in article feed.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
- [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [ ] I have documented the changes (where applicable)
