### PR TITLE
Feature/inrel 4797 coupon overview

### DIFF
--- a/modules/infinite_views/infinite_views.module
+++ b/modules/infinite_views/infinite_views.module
@@ -8,8 +8,39 @@
 use Drupal\block\Entity\Block;
 use Drupal\Core\Url;
 use Drupal\taxonomy\Entity\Term;
+use Drupal\views\Views;
 use Drupal\views\ViewExecutable;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ */
+function infinite_views_form_views_exposed_form_alter(&$form, $form_state, $form_id) {
+  \Drupal::logger('exposed_form_coupon_overview')->info($form_id);
+  if ($form_id == 'views_exposed_form') {
+    if ($form['#id'] == 'views-exposed-form-coupon-overview-page-1') {
+      // We use another view to get the actually used taxonomy terms. The
+      // view is cached and the cache should be invalidated when the coupons
+      // are updated.
+      $args = ['coupon', 'brands'];
+      $view = Views::getView('referenced_terms');
+      $view->setDisplay('default');
+      $view->setArguments($args);
+      $view->execute();
+      $result = $view->result;
+      $current_elements = $form['shop']['#options'];
+      $used_elements = [];
+      foreach ($result as $element) {
+        $used_elements[$element->tid] = $element->tid;
+      }
+      $unused_elements = array_diff_key($current_elements, $used_elements);
+      foreach ($unused_elements as $idx => $value) {
+        unset($form['shop']['#options'][$idx]);
+      }
+    }
+  }
+}
 
 /**
  * Implements hook_views_pre_view().

--- a/modules/infinite_views/infinite_views.module
+++ b/modules/infinite_views/infinite_views.module
@@ -41,7 +41,6 @@ function infinite_views_form_views_exposed_form_alter(&$form, $form_state, $form
       foreach ($unused_elements as $idx => $value) {
         unset($form['shop']['#options'][$idx]);
       }
-      $form['shop']['#type'] = 'checkboxes';
     }
   }
 }

--- a/modules/infinite_views/infinite_views.module
+++ b/modules/infinite_views/infinite_views.module
@@ -43,18 +43,12 @@ function infinite_views_form_views_exposed_form_alter(&$form, $form_state, $form
       $used_elements = array_column($result, 'tid', 'tid');
       // only use options that are actually used
       $unused_elements = array_diff_key($current_elements, $used_elements);
-      foreach ($unused_elements as $idx => $value) {
-        unset($form['shop']['#options'][$idx]);
-      }
+      $form['shop']['#options'] = array_diff_key($current_elements, $unused_elements);
 
       // now the same for channels
       $all_channels = $form['channel']['#options'];
       $wanted_channels = ['Fashion', 'Beauty', 'Livestyle'];
-      foreach ($all_channels as $idx => $channel) {
-        if (!in_array($channel, $wanted_channels)) {
-          unset($form['channel']['#options'][$idx]);
-        }
-      }
+      $form['channel']['#options'] = array_intersect($all_channels, $wanted_channels);
     }
   }
 }

--- a/modules/infinite_views/infinite_views.module
+++ b/modules/infinite_views/infinite_views.module
@@ -17,9 +17,12 @@ use Drupal\views\Plugin\views\query\QueryPluginBase;
  *
  */
 function infinite_views_form_views_exposed_form_alter(&$form, $form_state, $form_id) {
-  \Drupal::logger('exposed_form_coupon_overview')->info($form_id);
   if ($form_id == 'views_exposed_form') {
-    if ($form['#id'] == 'views-exposed-form-coupon-overview-page-1') {
+    if (
+      ($form['#id'] == 'views-exposed-form-coupon-overview-page-1')
+      ||
+      ($form['#id'] == 'views-exposed-form-coupon-term-related-embed-1')
+    ) {
       // We use another view to get the actually used taxonomy terms. The
       // view is cached and the cache should be invalidated when the coupons
       // are updated.

--- a/modules/infinite_views/infinite_views.module
+++ b/modules/infinite_views/infinite_views.module
@@ -38,6 +38,7 @@ function infinite_views_form_views_exposed_form_alter(&$form, $form_state, $form
       foreach ($unused_elements as $idx => $value) {
         unset($form['shop']['#options'][$idx]);
       }
+      $form['shop']['#type'] = 'checkboxes';
     }
   }
 }

--- a/modules/infinite_views/infinite_views.module
+++ b/modules/infinite_views/infinite_views.module
@@ -47,7 +47,7 @@ function infinite_views_form_views_exposed_form_alter(&$form, $form_state, $form
 
       // now the same for channels
       $all_channels = $form['channel']['#options'];
-      $wanted_channels = ['Fashion', 'Beauty', 'Livestyle'];
+      $wanted_channels = ['Fashion', 'Beauty', 'Lifestyle'];
       $form['channel']['#options'] = array_intersect($all_channels, $wanted_channels);
     }
   }

--- a/modules/infinite_views/infinite_views.module
+++ b/modules/infinite_views/infinite_views.module
@@ -46,6 +46,15 @@ function infinite_views_form_views_exposed_form_alter(&$form, $form_state, $form
       foreach ($unused_elements as $idx => $value) {
         unset($form['shop']['#options'][$idx]);
       }
+
+      // now the same for channels
+      $all_channels = $form['channel']['#options'];
+      $wanted_channels = ['Fashion', 'Beauty', 'Livestyle'];
+      foreach ($all_channels as $idx => $channel) {
+        if (!in_array($channel, $wanted_channels)) {
+          unset($form['channel']['#options'][$idx]);
+        }
+      }
     }
   }
 }

--- a/modules/infinite_views/infinite_views.module
+++ b/modules/infinite_views/infinite_views.module
@@ -26,17 +26,22 @@ function infinite_views_form_views_exposed_form_alter(&$form, $form_state, $form
       // We use another view to get the actually used taxonomy terms. The
       // view is cached and the cache should be invalidated when the coupons
       // are updated.
-      $args = ['coupon', 'brands'];
+      if ($form['#id'] == 'views-exposed-form-coupon-term-related-embed-1') {
+        $tid = \Drupal::routeMatch()->getParameter('taxonomy_term')->id();
+        $args = ['coupon', 'brands', $tid];
+      }
+      else {
+        $args = ['coupon', 'brands'];
+      }
       $view = Views::getView('referenced_terms');
       $view->setDisplay('default');
       $view->setArguments($args);
       $view->execute();
       $result = $view->result;
       $current_elements = $form['shop']['#options'];
-      $used_elements = [];
-      foreach ($result as $element) {
-        $used_elements[$element->tid] = $element->tid;
-      }
+      // get term ids from view result
+      $used_elements = array_column($result, 'tid', 'tid');
+      // only use options that are actually used
       $unused_elements = array_diff_key($current_elements, $used_elements);
       foreach ($unused_elements as $idx => $value) {
         unset($form['shop']['#options'][$idx]);


### PR DESCRIPTION
this leaves only terms in the selection that are 

1) published

and

2) have a published coupon that references them

It uses a view to get this information, to get proper caching.

This view needs to be present for this to work. 

shared/views.view.referenced_terms.yml
 
is available on the corresponding branch,