### PR TITLE
INREL-0: Remove dependencies to core UI modules from info YML files

### DIFF
--- a/modules/infinite_article/infinite_article.info.yml
+++ b/modules/infinite_article/infinite_article.info.yml
@@ -8,8 +8,6 @@ dependencies:
   - node
   - field
   - field_group
-  - field_ui
-  - menu_ui
   - options
   - paragraphs
   - scheduler

--- a/modules/infinite_media/infinite_media.info.yml
+++ b/modules/infinite_media/infinite_media.info.yml
@@ -7,7 +7,6 @@ version: 8.x-1.x-dev
 dependencies:
   - datetime
   - field
-  - field_ui
   - focal_point
   - image
   - inline_entity_form

--- a/modules/infinite_media_base/infinite_media_base.info.yml
+++ b/modules/infinite_media_base/infinite_media_base.info.yml
@@ -6,7 +6,6 @@ core: 8.x
 version: 8.x-1.x-dev
 dependencies:
   - field
-  - field_ui
   - focal_point
   - image
   - inline_entity_form


### PR DESCRIPTION
Removing the core UI dependencies is required to disable UI modules on non-local environments.